### PR TITLE
Relax version bounds

### DIFF
--- a/microaeson.cabal
+++ b/microaeson.cabal
@@ -78,10 +78,10 @@ test-suite microaeson
                    , containers
 
   -- dependencies requiring constraints
-  build-depends:     aeson                ^>= 1.3.1.0
-                   , QuickCheck           ^>= 2.11.3
+  build-depends:     aeson                >= 1.3.1.0 && < 1.5
+                   , QuickCheck           >= 2.11.3 && < 2.14
                    , quickcheck-instances ^>= 0.3.16
-                   , tasty                ^>= 1.0.1.1
+                   , tasty                >= 1.0.1.1 && < 1.3
                    , tasty-quickcheck     ^>= 0.10
                    , text                 ^>= 1.2.2.2
                    , unordered-containers ^>= 0.2.8.0


### PR DESCRIPTION
Some of the version bounds lead to build failures in newer GHC versions.